### PR TITLE
Using SetSensorLight() instead of SetSensorType() for NXT light sensors

### DIFF
--- a/RobotNXT/NEPODefs.h
+++ b/RobotNXT/NEPODefs.h
@@ -262,12 +262,11 @@ int SensorHtColor(int port, string mode) {
 int _readLightSensor(int port, int mode) {
     if (mode != _LIGHT_SENSOR_MODE) {
         if (mode == 1) {
-            SetSensorType(port, SENSOR_TYPE_LIGHT_ACTIVE);
+            SetSensorLight(port, true);
         } else if (mode == 2) {
-            SetSensorType(port, SENSOR_TYPE_LIGHT_INACTIVE);
+            SetSensorLight(port, false);
         }
         _LIGHT_SENSOR_MODE = mode;
-        ResetSensor(port);
     }
     return Sensor(port);
 }


### PR DESCRIPTION
Fixes issue [#1090](https://github.com/OpenRoberta/openroberta-lab/issues/1090) 
by replacing: SetSensorType (const byte &port, byte type)
 with: SetSensorLight (const byte &port, bool bActive=true)

not tested yet.